### PR TITLE
Update grakkit-minestom to support recent Minestom version

### DIFF
--- a/minestom/build.gradle
+++ b/minestom/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
 jar {
    archiveBaseName.set('grakkit')
-   archiveClassifier.set('paper')
+   archiveClassifier.set('minestom')
    archiveVersion.set(project.property('grakkitVersion'))
 }
 

--- a/minestom/build.gradle
+++ b/minestom/build.gradle
@@ -14,7 +14,7 @@ dependencies {
    implementation "org.graalvm.truffle:truffle-api:${graalVersion}"
 
    // platform-specific deps
-   compileOnly 'com.github.Minestom:Minestom:89a09f326e'
+   compileOnly 'com.github.Minestom:Minestom:fc90fe8'
 }
 
 jar {

--- a/minestom/src/main/java/grakkit/Main.java
+++ b/minestom/src/main/java/grakkit/Main.java
@@ -5,22 +5,24 @@ import net.minestom.server.MinecraftServer;
 import net.minestom.server.extensions.Extension;
 
 import net.minestom.server.timer.SchedulerManager;
+import net.minestom.server.timer.Scheduler;
 import net.minestom.server.utils.time.TimeUnit;
+import net.minestom.server.timer.TaskSchedule;
 
 public class Main extends Extension {
    private SchedulerManager schedulerManager = MinecraftServer.getSchedulerManager();
    @Override
 
-   public LoadStatus initialize() {
+   public void initialize() {
+      Scheduler scheduler = MinecraftServer.getSchedulerManager();
+
       Grakkit.patch(new Loader(this.getClass().getClassLoader())); // CORE - patch class loader with GraalJS
-      schedulerManager.buildTask(() -> {
-         schedulerManager.buildTask(() -> {
-            Grakkit.tick();
-         }).repeat(1, TimeUnit.TICK).schedule(); // CORE - run task loop
-         Grakkit.init(this.getDataDirectory().toString()); // CORE - initialize
-      }).delay(50, TimeUnit.MILLISECOND).schedule(); // delay 1/2 a second
+      Grakkit.init(this.getDataDirectory().toString());
+      scheduler.submitTask(() -> {
+          Grakkit.tick();
+          return TaskSchedule.seconds(1);
+      });
       this.getLogger().info("[Grakkit] Initialized!");
-      return LoadStatus.SUCCESS;
    }
    @Override
    public void terminate() {

--- a/minestom/src/main/java/grakkit/Main.java
+++ b/minestom/src/main/java/grakkit/Main.java
@@ -5,8 +5,6 @@ import net.minestom.server.MinecraftServer;
 import net.minestom.server.extensions.Extension;
 
 import net.minestom.server.timer.SchedulerManager;
-import net.minestom.server.timer.Scheduler;
-import net.minestom.server.utils.time.TimeUnit;
 import net.minestom.server.timer.TaskSchedule;
 
 public class Main extends Extension {
@@ -14,11 +12,9 @@ public class Main extends Extension {
    @Override
 
    public void initialize() {
-      Scheduler scheduler = MinecraftServer.getSchedulerManager();
-
       Grakkit.patch(new Loader(this.getClass().getClassLoader())); // CORE - patch class loader with GraalJS
       Grakkit.init(this.getDataDirectory().toString());
-      scheduler.submitTask(() -> {
+      schedulerManager.submitTask(() -> {
           Grakkit.tick();
           return TaskSchedule.seconds(1);
       });

--- a/minestom/src/main/resources/META-INF/extension.json
+++ b/minestom/src/main/resources/META-INF/extension.json
@@ -1,5 +1,0 @@
-{
-   "entrypoint": "grakkit.Main",
-   "name": "grakkit",
-   "version": "${grakkitVersion}"
-}

--- a/minestom/src/main/resources/extension.json
+++ b/minestom/src/main/resources/extension.json
@@ -1,0 +1,5 @@
+{
+   "entrypoint": "grakkit.Main",
+   "name": "grakkit",
+   "version": "${grakkitVersion}"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'grakkit'
-include 'common', 'paper'
+include 'common', 'paper', 'minestom'


### PR DESCRIPTION
This request aims at fixing a few things

- Re-locate extension.json from META-INF to root folder
- Remove LoadStatus as it was removed
- Remove use of deprecated TimeUnit.TICK
- Adds a minestom option for gradle
- Rename the "paper" build name when you're actually building Minestom
- Updates Minestom commit